### PR TITLE
Add Docker Compose deployment with Caddy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.git

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,5 +1,5 @@
-:80 {
-    root * dist
+mentor-bot.ru, xn----btbk1aggcnqf.xn--p1ai {
+    root * /usr/share/caddy
     try_files {path} /index.html
     file_server
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM caddy:2-alpine
+COPY Caddyfile /etc/caddy/Caddyfile
+COPY --from=build /app/dist /usr/share/caddy
+EXPOSE 80 443
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  web:
+    build: .
+    ports:
+      - "80:80"
+      - "443:443"
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- serve built assets with Caddy for mentor-bot.ru and xn----btbk1aggcnqf.xn--p1ai
- add Dockerfile and docker-compose for containerized deployment
- ignore unnecessary files during Docker builds

## Testing
- `npm test`
- `docker-compose build` *(fails: connection refused; Docker daemon not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a1aead43d08332bc099d4776374274