### PR TITLE
Enable Caddy to serve landing page on localhost

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,4 @@
-mentor-bot.ru, xn----btbk1aggcnqf.xn--p1ai {
+http://localhost, mentor-bot.ru, xn----btbk1aggcnqf.xn--p1ai {
     root * /usr/share/caddy
     try_files {path} /index.html
     file_server

--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ caddy run --config Caddyfile
 ```
 
 The provided `Caddyfile` serves the built assets and falls back to `index.html` for client-side routing.
+
+For local development, Caddy is also configured to serve the site on [http://localhost](http://localhost). You can run the site in a container with:
+
+```bash
+docker compose up --build
+```


### PR DESCRIPTION
## Summary
- allow Caddy to serve the app from `http://localhost`
- document running the site locally via Docker/Caddy

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1b44b3be08332a7e532c551023d17